### PR TITLE
Update Marios Ioannou's email address

### DIFF
--- a/data/profiles.ts
+++ b/data/profiles.ts
@@ -41,7 +41,7 @@ export const members: Contributor[] = [
     name: "Marios Ioannou",
     avatar: "public/avatars/marios-ioannou.jpg",
     twitter: "qedem0nstrandum",
-    email: "marios.ioannou@ethereum.org",
+    email: "marios@ethereum.org",
   },
 ]
 


### PR DESCRIPTION
## Summary
- Update Marios Ioannou's email from `marios.ioannou@ethereum.org` to `marios@ethereum.org` in the profiles data

## Changes
- Modified `data/profiles.ts` to use the shorter email format

🤖 Generated with [Claude Code](https://claude.com/claude-code)